### PR TITLE
split order

### DIFF
--- a/wildwood/_grow.py
+++ b/wildwood/_grow.py
@@ -337,7 +337,7 @@ def grow(
         )
 
         # TODO: add the max_depth option using something like
-        # is_leaf = is_leaf or (depth >= max_depth)
+        # is_leaf = (depth >= tree.max_depth)
         # This node is a terminal leaf, we won't try to split it
 
         # We don't split a node if it contains less than min_samples_split training

--- a/wildwood/_split.py
+++ b/wildwood/_split.py
@@ -7,7 +7,6 @@ a node.
 """
 
 import numpy as np
-from sklearn.preprocessing import normalize
 from numba import jit, boolean, uint8, uintp, float32, void
 from numba.types import Tuple
 from numba.experimental import jitclass
@@ -385,7 +384,7 @@ def try_feature_order_for_classifier_split(tree_context, node_context, feature, 
 
         # TODO: we shall pass the child impurity function as an argument to handle
         #  different impurities
-        # Get the impurities of the left and right childs
+        # Get the impurities of the left and right children
         impurity_left, impurity_right = gini_childs(
             n_classes,
             w_samples_train_left,

--- a/wildwood/forest.py
+++ b/wildwood/forest.py
@@ -1093,8 +1093,8 @@ class ForestClassifier(ForestBase, ClassifierMixin):
             if n_classes_ <= 2:
                 if self.verbose:
                     warn(
-                        'Only two classes where detected: switching to '
-                        'multiclass="multiclass" instead of "ovr"'
+                        'Only two classes were detected: switching to '
+                        'multiclass="multinomial" instead of "ovr"'
                     )
                 # We switch back to "multinomial" encoding
                 self.multiclass = "multinomial"


### PR DESCRIPTION
This PR adresses issue #47 i.e. it considers all orders according to modality proportions for splits along categorical features in classification

There seem to be some overfitting issues yet to be cleared