### PR TITLE
Prediction without binning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ dmypy.json
 
 # experiments results
 experiments/*.pickle
+experiments/results/

--- a/check_iris.py
+++ b/check_iris.py
@@ -39,7 +39,7 @@ logging.basicConfig(
     level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
 )
 
-np.set_printoptions(precision=2)
+np.set_printoptions(precision=6)
 
 
 random_state = 42
@@ -48,14 +48,16 @@ np.random.seed(0)
 
 iris = datasets.load_iris()
 
+X, y = iris["data"], iris["target"]
 
-covtype = datasets.fetch_covtype(download_if_missing=True)
+
+# covtype = datasets.fetch_covtype(download_if_missing=True)
 
 # rcv1_train = datasets.fetch_rcv1(subset='train', download_if_missing=True)
 # rcv1_test = datasets.fetch_rcv1(subset='test', download_if_missing=True)
 
-X = covtype.data
-y = covtype.target
+# X = covtype.data
+# y = covtype.target
 
 # X_train = rcv1_train.data
 # y_train = rcv1_train.target
@@ -76,7 +78,7 @@ clf = ForestClassifier(**clf_kwargs)
 
 
 X_train, X_test, y_train, y_test = train_test_split(
-    X, y, test_size=0.3, random_state=42
+    X, y, shuffle=True, test_size=0.3, random_state=42
 )
 
 tic = time()
@@ -93,6 +95,11 @@ tic = time()
 y_pred = clf.predict(X_test)
 toc = time()
 print("time to predict: ", toc - tic)
+
+tic = time()
+y_scores_no_binning = clf.predict_proba(X_test, False)
+toc = time()
+print("time to predict_proba without binning: ", toc - tic)
 
 cm = confusion_matrix(y_test, y_pred)
 acc = accuracy_score(y_test, y_pred)

--- a/wildwood/_grow.py
+++ b/wildwood/_grow.py
@@ -374,9 +374,10 @@ def grow(
         # If we did not find a split then the node is a leaf, since we can't split it
         is_leaf = is_leaf or not found_split
 
-        # TODO: correct this when actually using the threshold instead of
-        #  bin_threshold
-        threshold = 0.42
+        if is_split_categorical:
+            threshold = 0.42  # we do not need threshold, while the split is on categorical feature
+        else:
+            threshold = tree_context.bin_thresholds[feature][bin]
 
         node_id = add_node_tree(
             # The tree
@@ -391,7 +392,7 @@ def grow(
             is_leaf,
             # The feature used for splitting
             feature,
-            # NOT USED FOR NOW
+            # The numerical threshold used for splitting
             threshold,
             # The bin threshold used for splitting
             bin,

--- a/wildwood/_tree_context.py
+++ b/wildwood/_tree_context.py
@@ -97,6 +97,8 @@ tree_context_type = [
     #
     # A "buffer" used in the split_indices function
     ("right_buffer", uintp[::1]),
+    # bin thresholds
+    ("bin_thresholds", float32[:, :]),
 ]
 
 
@@ -133,7 +135,7 @@ class TreeClassifierContext:
         valid_indices,
         n_classes,
         max_bins,
-        n_bins_per_feature,
+        # n_bins_per_feature,
         max_features,
         min_samples_split,
         min_samples_leaf,
@@ -142,6 +144,7 @@ class TreeClassifierContext:
         step,
         is_categorical,
         cat_split_strategy,
+        bin_thresholds,
     ):
         init_tree_context(
             self,
@@ -157,6 +160,7 @@ class TreeClassifierContext:
             aggregation,
             step,
             is_categorical,
+            bin_thresholds,
         )
         self.n_classes = n_classes
         self.dirichlet = dirichlet
@@ -183,6 +187,7 @@ class TreeRegressorContext:
         aggregation,
         step,
         is_categorical,
+        bin_thresholds,
     ):
         init_tree_context(
             self,
@@ -198,6 +203,7 @@ class TreeRegressorContext:
             aggregation,
             step,
             is_categorical,
+            bin_thresholds,
         )
 
 
@@ -221,6 +227,7 @@ TreeRegressorContextType = get_type(TreeRegressorContext)
             boolean,
             float32,
             boolean[::1],
+            float32[:, :],  # TODO: for bin_thresholds, would float32[::1, ::1] be better?
         ),
         void(
             TreeRegressorContextType,
@@ -236,6 +243,7 @@ TreeRegressorContextType = get_type(TreeRegressorContext)
             boolean,
             float32,
             boolean[::1],
+            float32[:, :],
         ),
     ],
     nopython=NOPYTHON,
@@ -256,6 +264,7 @@ def init_tree_context(
     aggregation,
     step,
     is_categorical,
+    bin_thresholds,
 ):
     tree_context.X = X
     tree_context.y = y
@@ -271,6 +280,7 @@ def init_tree_context(
     tree_context.partition_train = train_indices.copy()
     tree_context.partition_valid = valid_indices.copy()
     tree_context.is_categorical = is_categorical.copy()
+    tree_context.bin_thresholds = bin_thresholds.copy()
 
     n_samples, n_features = X.shape
     tree_context.n_samples = n_samples

--- a/wildwood/tree.py
+++ b/wildwood/tree.py
@@ -62,6 +62,7 @@ class TreeBase(BaseEstimator, metaclass=ABCMeta):
         categorical_features,
         is_categorical,
         max_features,
+        bin_thresholds,
         random_state,
         verbose=0,
     ):
@@ -81,6 +82,7 @@ class TreeBase(BaseEstimator, metaclass=ABCMeta):
         self.categorical_features = categorical_features
         self.is_categorical = is_categorical
         self.max_features = max_features
+        self.bin_thresholds = bin_thresholds
         self.random_state = random_state
         self.verbose = verbose
 
@@ -147,6 +149,7 @@ class TreeClassifier(ClassifierMixin, TreeBase):
         categorical_features,
         is_categorical,
         max_features,
+        bin_thresholds,
         random_state,
         cat_split_strategy,
         verbose=0,
@@ -163,6 +166,7 @@ class TreeClassifier(ClassifierMixin, TreeBase):
             categorical_features=categorical_features,
             is_categorical=is_categorical,
             max_features=max_features,
+            bin_thresholds=bin_thresholds,
             random_state=random_state,
             verbose=verbose,
         )
@@ -174,12 +178,12 @@ class TreeClassifier(ClassifierMixin, TreeBase):
 
     def fit(self, X, y, train_indices, valid_indices, sample_weights):
         n_classes = self.n_classes
-        max_bins = self.n_bins - 1
+        # max_bins = self.n_bins - 1
         random_state = self.random_state
         # TODO: on obtiendra cette info via le binner qui est dans la foret
         n_samples, n_features = X.shape
-        n_bins_per_feature = max_bins * np.ones(n_features)
-        n_bins_per_feature = n_bins_per_feature.astype(np.intp)
+        # n_bins_per_feature = max_bins * np.ones(n_features)
+        # n_bins_per_feature = n_bins_per_feature.astype(np.intp)
 
         # Create the tree object, which is mostly a data container for the nodes
         tree = _TreeClassifier(n_features, n_classes, random_state)
@@ -195,7 +199,6 @@ class TreeClassifier(ClassifierMixin, TreeBase):
             valid_indices,
             self.n_classes,
             self.n_bins - 1,
-            n_bins_per_feature,
             self.max_features,
             self.min_samples_split,
             self.min_samples_leaf,
@@ -204,6 +207,7 @@ class TreeClassifier(ClassifierMixin, TreeBase):
             self._step,
             self.is_categorical,
             self.cat_split_strategy,
+            self.bin_thresholds,
         )
 
         node_context = NodeClassifierContext(tree_context)
@@ -223,9 +227,9 @@ class TreeClassifier(ClassifierMixin, TreeBase):
         self._tree_context = tree_context
         return self
 
-    def predict_proba(self, X):
+    def predict_proba(self, X, data_binning):
         proba = tree_classifier_predict_proba(
-            self._tree, X, self._tree_context.aggregation, self._tree_context.step
+            self._tree, X, self._tree_context.aggregation, self._tree_context.step, data_binning=data_binning
         )
         return proba
 
@@ -266,6 +270,7 @@ class TreeRegressor(TreeBase, RegressorMixin):
         categorical_features=None,
         is_categorical=None,
         max_features="auto",
+        bin_thresholds=None,
         random_state=None,
         verbose=0,
     ):
@@ -281,17 +286,18 @@ class TreeRegressor(TreeBase, RegressorMixin):
             categorical_features=categorical_features,
             is_categorical=is_categorical,
             max_features=max_features,
+            bin_thresholds=bin_thresholds,
             random_state=random_state,
             verbose=verbose,
         )
 
     def fit(self, X, y, train_indices, valid_indices, sample_weights):
-        max_bins = self.n_bins - 1
+        # max_bins = self.n_bins - 1
         random_state = self.random_state
         # TODO: on obtiendra cette info via le binner qui est dans la foret
         n_samples, n_features = X.shape
-        n_bins_per_feature = max_bins * np.ones(n_features)
-        n_bins_per_feature = n_bins_per_feature.astype(np.intp)
+        # n_bins_per_feature = max_bins * np.ones(n_features)
+        # n_bins_per_feature = n_bins_per_feature.astype(np.intp)
 
         # Create the tree object, which is mostly a data container for the nodes
         tree = _TreeRegressor(n_features, random_state)
@@ -312,6 +318,7 @@ class TreeRegressor(TreeBase, RegressorMixin):
             self.aggregation,
             self._step,
             self.is_categorical,
+            self.bin_thresholds,
         )
 
         node_context = NodeRegressorContext(tree_context)


### PR DESCRIPTION
This PR replace #45 

With this PR, it would be able to make prediction without binning by doing ` clf.predict_proba(X_test, data_binning=False)`.

Briefly, what this PR changes:
- add boolean `data_binning` argument whenever it is relevant (`ForestClassifier.predict_proba`, `find_leaf`, `tree_classifier_predict_proba`...)
    - `data_binning` is optional and default to True, so that previous behaviours of this methods are not affected
-  make use of `tree_context.bin_thresholds[feature][bin]` to register **true** split threshold for numerical features
    - for this end, add a `bin_threshold` field for `tree_context`, which comes from `.bin_thresholds_` of (sklearn's) Binnner
- add a test `test_pred_no_binning_iris`

Some stuffs I need to check before merge:
- what happens when there are categorical features and numerical features??
- observation: it is not always faster while putting `data_binning=False`, even in the case `data_binning=False` is faster, the gain is not important; it this normal?
- with `Dataset` implemented in `preprecessing`, is doing `data_binning=False` stuffs still relevant??
- might need to be adapted once our own binner implemented
