### PR TITLE
Add support for Entropy criterion

### DIFF
--- a/check_cat.py
+++ b/check_cat.py
@@ -37,6 +37,7 @@ clf = ForestClassifier(
     categorical_features=dataset.categorical_features_,
     n_jobs=1,
     class_weight="balanced",
+    criterion="entropy",
 )
 clf.fit(X_train, y_train)
 y_scores_train = clf.predict_proba(X_train)
@@ -53,6 +54,7 @@ clf = ForestClassifier(
     aggregation=False,
     max_features=None,
     # categorical_features=dataset.categorical_features_,
+    criterion="entropy",
     n_jobs=1,
     class_weight="balanced",
 )
@@ -76,6 +78,7 @@ clf = ForestClassifier(
     max_features=None,
     n_jobs=1,
     class_weight="balanced",
+    criterion="entropy",
 )
 clf.fit(X_train, y_train)
 y_scores_train = clf.predict_proba(X_train)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -108,6 +108,7 @@ def check_nodes(nodes, bin_partitions, aggregation):
 @pytest.mark.parametrize(
     "one_hot_encode, use_categoricals", [(False, False), (False, True), (True, False)]
 )
+@pytest.mark.parametrize("criterion", ("gini", "entropy"))
 def test_nodes_on_adult(
     n_estimators,
     aggregation,
@@ -121,6 +122,7 @@ def test_nodes_on_adult(
     cat_split_strategy,
     one_hot_encode,
     use_categoricals,
+    criterion,
 ):
     dataset = load_adult()
     dataset.test_size = 1.0 / 5
@@ -137,6 +139,7 @@ def test_nodes_on_adult(
         multiclass=multiclass,
         cat_split_strategy=cat_split_strategy,
         aggregation=aggregation,
+        criterion=criterion,
         max_features=max_features,
         class_weight=class_weight,
         categorical_features=categorical_features,
@@ -166,6 +169,7 @@ def test_nodes_on_adult(
 @pytest.mark.parametrize(
     "one_hot_encode, use_categoricals", [(False, False), (False, True), (True, False)]
 )
+@pytest.mark.parametrize("criterion", ("gini", "entropy"))
 def test_nodes_on_car(
     n_estimators,
     aggregation,
@@ -179,6 +183,7 @@ def test_nodes_on_car(
     cat_split_strategy,
     one_hot_encode,
     use_categoricals,
+    criterion,
 ):
     dataset = load_car()
     dataset.test_size = 1.0 / 5
@@ -195,6 +200,7 @@ def test_nodes_on_car(
         multiclass=multiclass,
         cat_split_strategy=cat_split_strategy,
         aggregation=aggregation,
+        criterion=criterion,
         max_features=max_features,
         class_weight=class_weight,
         categorical_features=categorical_features,
@@ -224,6 +230,7 @@ def test_nodes_on_car(
 @pytest.mark.parametrize(
     "one_hot_encode, use_categoricals", [(False, False), (False, True), (True, False)]
 )
+@pytest.mark.parametrize("criterion", ("gini", "entropy"))
 def test_nodes_on_churn(
     n_estimators,
     aggregation,
@@ -237,6 +244,7 @@ def test_nodes_on_churn(
     cat_split_strategy,
     one_hot_encode,
     use_categoricals,
+    criterion,
 ):
     dataset = load_car()
     dataset.test_size = 1.0 / 5
@@ -253,6 +261,7 @@ def test_nodes_on_churn(
         multiclass=multiclass,
         cat_split_strategy=cat_split_strategy,
         aggregation=aggregation,
+        criterion=criterion,
         max_features=max_features,
         class_weight=class_weight,
         categorical_features=categorical_features,
@@ -327,6 +336,7 @@ def test_nodes_on_boston(
 @pytest.mark.parametrize(
     "min_samples_split, min_samples_leaf", [(2, 1), (13, 7), (3, 5)]
 )
+@pytest.mark.parametrize("criterion", ("gini", "entropy"))
 def test_min_samples_split_min_samples_leaf_on_adult(
     aggregation,
     max_features,
@@ -335,6 +345,7 @@ def test_min_samples_split_min_samples_leaf_on_adult(
     use_categoricals,
     min_samples_split,
     min_samples_leaf,
+    criterion,
 ):
     dataset = load_adult()
     dataset.test_size = 1.0 / 5
@@ -358,6 +369,7 @@ def test_min_samples_split_min_samples_leaf_on_adult(
         multiclass=multiclass,
         aggregation=aggregation,
         max_features=max_features,
+        criterion=criterion,
         min_samples_split=min_samples_split,
         min_samples_leaf=min_samples_leaf,
         class_weight=class_weight,

--- a/tests/test_forest.py
+++ b/tests/test_forest.py
@@ -214,6 +214,16 @@ class TestForestClassifier(object):
         with pytest.raises(ValueError, match="verbose must be boolean"):
             clf.verbose = 1
 
+    def test_criterion(self):
+        clf = ForestClassifier()
+        assert clf.criterion == "gini"
+        with pytest.raises(ValueError, match="criterion must be a string"):
+            clf.criterion = 1
+        clf.criterion = "entropy"
+        assert clf.criterion == "entropy"
+        with pytest.raises(ValueError, match="Unknown criterion: other"):
+            clf.criterion = "other"
+
     def test_loss(self):
         clf = ForestClassifier()
         assert clf.loss == "log"
@@ -521,6 +531,17 @@ class TestForestClassifier(object):
         y_score = clf.predict_proba(X_test)
         assert roc_auc_score(y_test, y_score, multi_class="ovo") >= 0.985
 
+        clf = ForestClassifier(
+            class_weight="balanced", random_state=42, criterion="entropy"
+        )
+        clf.fit(X_train, y_train)
+        y_score = clf.predict_proba(X_test)
+        assert roc_auc_score(y_test, y_score, multi_class="ovo") >= 0.985
+        clf = ForestClassifier(random_state=42, criterion="entropy")
+        clf.fit(X_train, y_train)
+        y_score = clf.predict_proba(X_test)
+        assert roc_auc_score(y_test, y_score, multi_class="ovo") >= 0.985
+
     def test_performance_cat_split_strategy_iris(self):
         iris = self.iris
         X, y = iris["data"], iris["target"]
@@ -547,6 +568,15 @@ class TestForestClassifier(object):
         y_score = clf.predict_proba(X_test)
         assert roc_auc_score(y_test, y_score[:, 1]) >= 0.98
         clf = ForestClassifier(random_state=42)
+        clf.fit(X_train, y_train)
+        y_score = clf.predict_proba(X_test)
+        assert roc_auc_score(y_test, y_score[:, 1]) >= 0.98
+        clf = ForestClassifier(class_weight="balanced", random_state=42,
+                               criterion="entropy")
+        clf.fit(X_train, y_train)
+        y_score = clf.predict_proba(X_test)
+        assert roc_auc_score(y_test, y_score[:, 1]) >= 0.98
+        clf = ForestClassifier(random_state=42, criterion="entropy")
         clf.fit(X_train, y_train)
         y_score = clf.predict_proba(X_test)
         assert roc_auc_score(y_test, y_score[:, 1]) >= 0.98

--- a/wildwood/_tree_context.py
+++ b/wildwood/_tree_context.py
@@ -97,6 +97,9 @@ tree_context_type = [
     #
     # A "buffer" used in the split_indices function
     ("right_buffer", uintp[::1]),
+    #
+    # Criteria: "gini" or "entropy" or "mse", in int (according to _utils.criteria_mapping)
+    ("criterion", uint8)
 ]
 
 
@@ -142,6 +145,7 @@ class TreeClassifierContext:
         step,
         is_categorical,
         cat_split_strategy,
+        criterion,
     ):
         init_tree_context(
             self,
@@ -157,6 +161,7 @@ class TreeClassifierContext:
             aggregation,
             step,
             is_categorical,
+            criterion,
         )
         self.n_classes = n_classes
         self.dirichlet = dirichlet
@@ -183,6 +188,7 @@ class TreeRegressorContext:
         aggregation,
         step,
         is_categorical,
+        criterion,
     ):
         init_tree_context(
             self,
@@ -198,6 +204,7 @@ class TreeRegressorContext:
             aggregation,
             step,
             is_categorical,
+            criterion,
         )
 
 
@@ -221,6 +228,7 @@ TreeRegressorContextType = get_type(TreeRegressorContext)
             boolean,
             float32,
             boolean[::1],
+            uint8,
         ),
         void(
             TreeRegressorContextType,
@@ -236,6 +244,7 @@ TreeRegressorContextType = get_type(TreeRegressorContext)
             boolean,
             float32,
             boolean[::1],
+            uint8,
         ),
     ],
     nopython=NOPYTHON,
@@ -256,6 +265,7 @@ def init_tree_context(
     aggregation,
     step,
     is_categorical,
+    criterion,
 ):
     tree_context.X = X
     tree_context.y = y
@@ -268,6 +278,7 @@ def init_tree_context(
     tree_context.valid_indices = valid_indices
     tree_context.aggregation = aggregation
     tree_context.step = step
+    tree_context.criterion = criterion
     tree_context.partition_train = train_indices.copy()
     tree_context.partition_valid = valid_indices.copy()
     tree_context.is_categorical = is_categorical.copy()

--- a/wildwood/_utils.py
+++ b/wildwood/_utils.py
@@ -18,6 +18,16 @@ split_strategy_mapping = {
     "random": SPLIT_STRATEGY_RANDOM,
 }
 
+CRITERIA_GINI = 0
+CRITERIA_ENTROPY = 1
+CRITERIA_MSE = 3
+
+criteria_mapping = {
+    "gini": CRITERIA_GINI,
+    "entropy": CRITERIA_ENTROPY,
+    "mse": CRITERIA_MSE,
+}
+
 
 def get_numba_type(class_):
     """Gives the numba type of an object is numba.jit decorators are enabled and None

--- a/wildwood/forest.py
+++ b/wildwood/forest.py
@@ -24,7 +24,7 @@ from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_is_fitted
 
 from ._binning import Binner
-from ._utils import split_strategy_mapping
+from ._utils import split_strategy_mapping, criteria_mapping
 
 eps = np.finfo("float32").eps
 
@@ -381,7 +381,7 @@ class ForestBase(BaseEstimator):
                 TreeClassifier(
                     n_bins=n_bins,
                     n_classes=n_classes_per_tree,
-                    criterion=self.criterion,
+                    criterion=criteria_mapping[self.criterion],
                     loss=self.loss,
                     step=self.step,
                     aggregation=self.aggregation,
@@ -405,7 +405,7 @@ class ForestBase(BaseEstimator):
             trees = [
                 TreeRegressor(
                     n_bins=n_bins,
-                    criterion=self.criterion,
+                    criterion=criteria_mapping[self.criterion],
                     loss=self.loss,
                     step=self.step,
                     aggregation=self.aggregation,
@@ -1235,10 +1235,6 @@ class ForestClassifier(ForestBase, ClassifierMixin):
         return probas
 
     @property
-    def criterion(self):
-        return self._criterion
-
-    @property
     def loss(self):
         return self._loss
 
@@ -1252,15 +1248,19 @@ class ForestClassifier(ForestBase, ClassifierMixin):
             else:
                 self._loss = val
 
+    @property
+    def criterion(self):
+        return self._criterion
+
     @criterion.setter
     def criterion(self, val):
         if not isinstance(val, str):
             raise ValueError("criterion must be a string")
         else:
-            if val != "gini":
-                raise ValueError("Only criterion='gini' is supported for now")
-            else:
+            if val in {"gini", "entropy"}:
                 self._criterion = val
+            else:
+                raise ValueError("Unknown criterion: " + val)
 
     @property
     def dirichlet(self):

--- a/wildwood/tree.py
+++ b/wildwood/tree.py
@@ -204,6 +204,7 @@ class TreeClassifier(ClassifierMixin, TreeBase):
             self._step,
             self.is_categorical,
             self.cat_split_strategy,
+            self.criterion,
         )
 
         node_context = NodeClassifierContext(tree_context)
@@ -312,6 +313,7 @@ class TreeRegressor(TreeBase, RegressorMixin):
             self.aggregation,
             self._step,
             self.is_categorical,
+            self.criterion,
         )
 
         node_context = NodeRegressorContext(tree_context)


### PR DESCRIPTION
This PR would resolve #70. It does following:
- implement `entropy_node` and `entropy_childs` in `_impurity.py`
- add methods `apply_childs_impurity_function_clf` and `apply_childs_impurity_function_reg`, to be able to choose among multiple impurity criteria, in `_split.py`
- add field `criterion` for `tree_context` (in type int as mapped with `_utils.criteria_mapping`)
- add `test_criterion` in `test_forest.py` (very basic tests..)


- [ ] Are there more tests on criterion that I should add? 


Maybe in another PR:
- [ ] Add tests for ForestRegressor (with class`TestForestRegressor` in `test_forest.py`)